### PR TITLE
First attempt to patch Grimworld AM trader to carry lasgun ammo

### DIFF
--- a/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
+++ b/Defs/Ammo/Modded/Warhammer 40k/LasGun.xml
@@ -55,6 +55,7 @@
 			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<li>CE_AutoEnableCrafting_TableMachining</li>
 			<li>CE_AutoEnableCrafting_GWAmmoBench</li>
+      <li>CE_Lasgun_Ammo</li>
 		</tradeTags>
 		<thingCategories>
 			<li>AmmoLasgunPowerPack</li>

--- a/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
+++ b/ModPatches/Grimworld Hammer of the Imperium/Patches/Grimworld Hammer of the Imperium/CE_Patch_Traders.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="GW_AM_Trader"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Lasgun_Ammo</tradeTag>
+        <countRange>
+          <min>200</min>
+          <max>400</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+</Patch>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
